### PR TITLE
Fix: replaces java8 with openjdk8. removes java.sls

### DIFF
--- a/salt/example.top
+++ b/salt/example.top
@@ -31,11 +31,7 @@ base:
         - elife.hub
         #- elife.init # this is 'elife' at the very top
         # See https://github.com/elifesciences/jira-import/issues/4360
-        {% if salt['grains.get']('oscodename') == 'trusty' %}
-        - elife.java
-        {% else %}
-        - elife.java8
-        {% endif %}
+        - elife.openjdk8
         - elife.jenkins-scripts
         #- elife.known-hosts # part of elife.init
         #- elife.logging # part of elife.init


### PR DESCRIPTION
* replaces java8 with openjdk8
* removes java. according to builder-configuration top file, nothing is using it anymore
* depends on https://github.com/elifesciences/builder-base-formula/pull/230
