### PR TITLE
Skip PHP 7 testing on 14.04

### DIFF
--- a/salt/example.top
+++ b/salt/example.top
@@ -44,7 +44,9 @@ base:
         {% else %}
         - elife.newrelic-infrastructure
         {% endif %}
+        {% if salt['grains.get']('oscodename') != 'trusty' %}
         - elife.newrelic-php
+        {% endif %}
         #- elife.newrelic-python # needs some states to be specified in pillar to actually work
         - elife.nginx-error-pages
         {% if salt['grains.get']('oscodename') != 'trusty' %}

--- a/salt/example.top
+++ b/salt/example.top
@@ -47,7 +47,9 @@ base:
         - elife.newrelic-php
         #- elife.newrelic-python # needs some states to be specified in pillar to actually work
         - elife.nginx-error-pages
+        {% if salt['grains.get']('oscodename') != 'trusty' %}
         - elife.nginx-php7
+        {% endif %}
         - elife.nginx
         #- elife.nginx-upgrade-http # investigate, remove
         - elife.nodejs6
@@ -55,7 +57,9 @@ base:
         #- elife.nodejs # used in dashboard and elife-website, should be moved to dashboard or upgraded to nodejs6 (which is LTS)
         #- elife.no-more-daemon # investigate, remove
         # - elife.php5 # drop or move this into civi
+        {% if salt['grains.get']('oscodename') != 'trusty' %}
         - elife.php7
+        {% endif %}
         - elife.postfix-ses # proxies mail from postfix to Amazon SES
         - elife.postfix
         - elife.postgresql

--- a/salt/example.top
+++ b/salt/example.top
@@ -2,7 +2,6 @@ base:
     '*':
         - elife
         - elife.apache
-        - elife.apache-php7
         - elife.aws-cli
         #- elife.backups # part of elife.init
         #- elife.base # part of elife.init

--- a/salt/example.top
+++ b/salt/example.top
@@ -8,7 +8,9 @@ base:
         #- elife.base # part of elife.init
         #- elife.certificates # part of elife.apache and elife.nginx
         #- elife.collectd # investigate, remove
+        {% if osrelease != '14.04' %}
         - elife.composer
+        {% endif %}
         #- elife.daily-system-updates # part of elife.init
         #- elife.deploy-user # part of elife.init
         #- elife.dhcp # part of elife.init
@@ -21,7 +23,7 @@ base:
         # Gearman through the PPA doesn't work on 16.04, see:
         # https://github.com/elifesciences/builder-base-formula/pull/172#issuecomment-417200967
         #- elife.gearman
-        {% else %}
+        {% elif osrelease != '14.04' %}
         - elife.gearman
         {% endif %}
         - elife.docker
@@ -65,7 +67,9 @@ base:
         - elife.postfix-ses # proxies mail from postfix to Amazon SES
         - elife.postfix
         - elife.postgresql
+        {% if osrelease != '14.04' %}
         - elife.proofreader-php
+        {% endif %}
         - elife.python3
         - elife.python
         - elife.redis-server
@@ -84,5 +88,7 @@ base:
         #- elife.utils # part of elife.init. should this be part of elife.base ?
         - elife.uwsgi
         - elife.vsftpd
+        {% if osrelease != '14.04' %}
         - elife.yamldiff
+        {% endif %}
         - heavybox

--- a/salt/example.top
+++ b/salt/example.top
@@ -1,7 +1,6 @@
 base:
     '*':
         - elife
-        - elife.apache
         - elife.aws-cli
         #- elife.backups # part of elife.init
         #- elife.base # part of elife.init

--- a/salt/example.top
+++ b/salt/example.top
@@ -1,3 +1,5 @@
+{% set osrelease = salt['grains.get']('osrelease') %}
+
 base:
     '*':
         - elife
@@ -15,7 +17,7 @@ base:
         - elife.external-volume-srv
         #- elife.forced-dns # part of elife.init
         - elife.galen
-        {% if salt['grains.get']('oscodename') == 'xenial' %}
+        {% if osrelease == '16.04' %}
         # Gearman through the PPA doesn't work on 16.04, see:
         # https://github.com/elifesciences/builder-base-formula/pull/172#issuecomment-417200967
         #- elife.gearman
@@ -37,17 +39,17 @@ base:
         - elife.mysql-client
         - elife.mysql-server
         # skip elife.newrelic-infrastructure on 18.04 until supported
-        {% if salt['grains.get']('oscodename') == 'bionic' %}
+        {% if osrelease == '18.04' %}
         #- elife.newrelic-infrastructure
         {% else %}
         - elife.newrelic-infrastructure
         {% endif %}
-        {% if salt['grains.get']('oscodename') != 'trusty' %}
+        {% if osrelease != '14.04' %}
         - elife.newrelic-php
         {% endif %}
         #- elife.newrelic-python # needs some states to be specified in pillar to actually work
         - elife.nginx-error-pages
-        {% if salt['grains.get']('oscodename') != 'trusty' %}
+        {% if osrelease != '14.04' %}
         - elife.nginx-php7
         {% endif %}
         - elife.nginx
@@ -57,7 +59,7 @@ base:
         #- elife.nodejs # used in dashboard and elife-website, should be moved to dashboard or upgraded to nodejs6 (which is LTS)
         #- elife.no-more-daemon # investigate, remove
         # - elife.php5 # drop or move this into civi
-        {% if salt['grains.get']('oscodename') != 'trusty' %}
+        {% if osrelease != '14.04' %}
         - elife.php7
         {% endif %}
         - elife.postfix-ses # proxies mail from postfix to Amazon SES

--- a/salt/heavybox/init.sls
+++ b/salt/heavybox/init.sls
@@ -1,7 +1,2 @@
 echo 'hello, world':
     cmd.run
-
-extend:
-    apache2-server:
-        service.dead:
-            - name: apache2


### PR DESCRIPTION
Formula builds different from `heavybox` and `basebox` will continue to fail. But since we have decided to stop supporting this combination at least these base ones won't.