### PR TITLE
mysql57 removal

### DIFF
--- a/salt/example-deprecated.top
+++ b/salt/example-deprecated.top
@@ -1,5 +1,4 @@
 base:
     '*':
         - elife
-        - elife.mysql57 # deprecated, replaced by elife.mysql-server in 16.04
         - elife.pypi # only used by elife-libraries and partly by containers

--- a/salt/example.top
+++ b/salt/example.top
@@ -39,7 +39,6 @@ base:
         #- elife.known-hosts # part of elife.init
         #- elife.logging # part of elife.init
         - elife.mercurial
-        #- elife.mysql57 # deprecated, replaced by elife.mysql-server in 16.04
         - elife.mysql-client
         - elife.mysql-server
         # skip elife.newrelic-infrastructure on 18.04 until supported


### PR DESCRIPTION
replaces references to mysql57 with mysql-client and mysql-server