### PR TITLE
disables proofreader as composer 1 is going out of memory.

### DIFF
--- a/salt/example.top
+++ b/salt/example.top
@@ -59,7 +59,7 @@ base:
         - elife.postfix-ses # proxies mail from postfix to Amazon SES
         - elife.postfix
         - elife.postgresql
-        - elife.proofreader-php
+        #- elife.proofreader-php # lsh@2022-01-21: disabled as composer 1 is going OOM 
         #- elife.python # part of elife.init
         - elife.redis-server
         - elife.sidecars


### PR DESCRIPTION
causes builder-base-formula changes to fail.